### PR TITLE
theme's own config for mp4 mediatype

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,3 @@
+[mediaTypes]
+[mediaTypes."video/mp4"]
+suffixes = ["mp4", "m4v"]


### PR DESCRIPTION
The change in #8 was missing the media type override.
This fixes #10.