### PR TITLE
Remove empty whitespace in HTML output

### DIFF
--- a/layouts/shortcodes/video.html
+++ b/layouts/shortcodes/video.html
@@ -62,6 +62,6 @@
     <source src="{{ .RelPermalink }}" type="video/mp4" }}>
     {{ $video_dl = . }}
   {{ end }}
-  <p>{{ i18n "videoUnsupported" $video_dl | markdownify }}</p>
+  <p>{{ i18n "videoUnsupported" $video_dl | safeHTML}}</p>
 </video>
 {{ end }}

--- a/layouts/shortcodes/video.html
+++ b/layouts/shortcodes/video.html
@@ -1,4 +1,4 @@
-{{/*  hugo-video shortcode
+{{- /*  hugo-video shortcode
 /*
 /*    This file is part of hugo-video shortcode.
 /*    A Hugo component shortcode to embed videos using the HTML video element.
@@ -7,61 +7,61 @@
 /*    @source     https://github.com/martignoni/hugo-video
 /*    @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
 /*
-*/}}
+*/ -}}
 
-{{ $video_src := .Get "src" }}
-{{ $video_mp4 := "" }}
-{{ $video_webm := "" }}
-{{ $video_ogg := "" }}
-{{ $video_dl := "" }}
-{{ $width := "100%" }}
-{{ $filenotfound := true }}
-{{ $unsupportedfile := true }}
+{{- $video_src := .Get "src" -}}
+{{- $video_mp4 := "" -}}
+{{- $video_webm := "" -}}
+{{- $video_ogg := "" -}}
+{{- $video_dl := "" -}}
+{{- $width := "100%" -}}
+{{- $filenotfound := true -}}
+{{- $unsupportedfile := true -}}
 
-{{/* Find all files with filename (without suffix) matching "src" parameter. */}}
-{{ $video_files := (.Page.Resources.Match (printf "%s*" $video_src)) }}
+{{- /* Find all files with filename (without suffix) matching "src" parameter. */ -}}
+{{- $video_files := (.Page.Resources.Match (printf "%s*" $video_src)) -}}
 
-{{/* Find first image file with filename (without suffix) matching "src" parameter. */}}
-{{ $poster := ((.Page.Resources.ByType "image").GetMatch (printf "%s*" $video_src)) }}
+{{- /* Find first image file with filename (without suffix) matching "src" parameter. */ -}}
+{{- $poster := ((.Page.Resources.ByType "image").GetMatch (printf "%s*" $video_src)) -}}
 
-{{/* Find in page bundle all valid video files with matching name. */}}
-{{ with $video_files }}
-  {{ $filenotfound = false }}
-  {{ range . }}
-    {{ if or (in .MediaType.Suffixes "mp4") (in .MediaType.Suffixes "m4v") }}
-      {{ $unsupportedfile = false }}
-      {{ $video_mp4 = . }}
-    {{ end }}
-    {{ if (in .MediaType.Suffixes "webm") }}
-      {{ $unsupportedfile = false }}
-      {{ $video_webm = . }}
-    {{ end }}
-    {{ if (in .MediaType.Suffixes "ogv") }}
-      {{ $unsupportedfile = false }}
-      {{ $video_ogg = . }}
-    {{ end }}
-  {{ end }}
-{{ end }}
+{{- /* Find in page bundle all valid video files with matching name. */ -}}
+{{- with $video_files -}}
+  {{- $filenotfound = false -}}
+  {{- range . -}}
+    {{- if or (in .MediaType.Suffixes "mp4") (in .MediaType.Suffixes "m4v") -}}
+      {{- $unsupportedfile = false -}}
+      {{- $video_mp4 = . -}}
+    {{- end -}}
+    {{- if (in .MediaType.Suffixes "webm") -}}
+      {{- $unsupportedfile = false -}}
+      {{- $video_webm = . -}}
+    {{- end -}}
+    {{- if (in .MediaType.Suffixes "ogv") -}}
+      {{- $unsupportedfile = false -}}
+      {{- $video_ogg = . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 
-{{ if $filenotfound }}
-  {{/* No file of given name was found, we stop here. */}}
-  {{ errorf "No file with filename %q found." $video_src }}
-{{ else if $unsupportedfile }}
-  {{ errorf "No valid video file with filename %q found." $video_src }}
-{{ else }}
+{{- if $filenotfound -}}
+  {{- /* No file of given name was found, we stop here. */ -}}
+  {{- errorf "No file with filename %q found." $video_src -}}
+{{- else if $unsupportedfile -}}
+  {{- errorf "No valid video file with filename %q found." $video_src -}}
+{{- else -}}
 <video {{ if ne (.Get "controls") "false" }}controls {{ end }}preload="auto" width="{{ or (.Get "width") $width }}" {{ if eq (.Get "autoplay") "true" }}autoplay {{ end }}{{ if eq (.Get "loop") "true" }}loop {{ end }}{{ if eq (.Get "muted") "true" }}muted {{ end }}{{ with $poster }}poster="{{ .RelPermalink }}" {{ end }}class="html-video">
-  {{ with $video_webm }}
+  {{- with $video_webm }}
     <source src="{{ .RelPermalink }}" type="video/webm" }}>
-    {{ $video_dl = . }}
-  {{ end }}
-  {{ with $video_ogg }}
+    {{- $video_dl = . -}}
+  {{- end }}
+  {{- with $video_ogg }}
     <source src="{{ .RelPermalink }}" type="video/ogg" }}>
-    {{ $video_dl = . }}
-  {{ end }}
-  {{ with $video_mp4 }}
+    {{- $video_dl = . -}}
+  {{- end }}
+  {{- with $video_mp4 }}
     <source src="{{ .RelPermalink }}" type="video/mp4" }}>
-    {{ $video_dl = . }}
-  {{ end }}
+    {{- $video_dl = . -}}
+  {{- end }}
   <p>{{ i18n "videoUnsupported" $video_dl | markdownify }}</p>
 </video>
-{{ end }}
+{{- end -}}


### PR DESCRIPTION
Replace the {{ }} template tags with {{- -}} where appropriate to reduce
the number of empty lines in the produced HTML and leave it formatted
prettily.

This pull request only changes the formatting of the output, no logic changes are made.